### PR TITLE
Control over message id

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -12,11 +12,33 @@ function entryId(entry) {
   return entry.Id;
 }
 
-function entryFromMessage(message) {
+function entryFromObject(message) {
+  if (!message.id || !message.body) {
+    throw new Error('Object messages must have \'id\' and \'body\' props');
+  }
+
+  return {
+    Id: message.id,
+    MessageBody: message.body
+  };
+}
+
+function entryFromString(message) {
   return {
     Id: message,
     MessageBody: message
   };
+}
+
+function entryFromMessage(message) {
+  if (typeof message === 'string') {
+    return entryFromString(message);
+  }
+  else if (typeof message === 'object') {
+    return entryFromObject(message);
+  }
+
+  throw new Error('A message can either be an object or a string');
 }
 
 function createError(failedMessages) {

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -55,9 +55,16 @@ Producer.prototype._sendBatch = function(failedMessages, messages, startIndex, c
   var endIndex = startIndex + BATCH_SIZE;
   var batch = messages.slice(startIndex, endIndex);
   var params = {
-    Entries: batch.map(entryFromMessage),
     QueueUrl: this.queueUrl
   };
+
+  try {
+    params.Entries = batch.map(entryFromMessage);
+  }
+  catch (err) {
+    cb(err);
+    return;
+  }
 
   this.sqs.sendMessageBatch(params, function (err, result) {
     if (err) return cb(err);

--- a/test/producer.js
+++ b/test/producer.js
@@ -114,8 +114,32 @@ describe('Producer', function () {
   it('returns an error when object messages are not of shape {id, body}', function (done) {
     var errMessage = 'Object messages must have \'id\' and \'body\' props';
 
-    var message1 = { notId: 'notId1', body: 'body1' };
+    var message1 = { noId: 'noId1', body: 'body1' };
     var message2 = { id: 'id2', body: 'body2' };
+
+    producer.send(['foo', message1, message2], function (err) {
+      assert.equal(err.message, errMessage);
+      done();
+    });
+  });
+
+  it('returns an error when object messages are not of shape {id, body} 2', function (done) {
+    var errMessage = 'Object messages must have \'id\' and \'body\' props';
+
+    var message1 = { id: 'id1', noBody: 'noBody1' };
+    var message2 = { id: 'id2', body: 'body2' };
+
+    producer.send(['foo', message1, message2], function (err) {
+      assert.equal(err.message, errMessage);
+      done();
+    });
+  });
+
+  it('returns an error when object messages are not of shape {id, body} 3', function (done) {
+    var errMessage = 'Object messages must have \'id\' and \'body\' props';
+
+    var message1 = { id: 'id1', body: 'body1' };
+    var message2 = { noId: 'noId2', noBody: 'noBody2' };
 
     producer.send(['foo', message1, message2], function (err) {
       assert.equal(err.message, errMessage);


### PR DESCRIPTION
we needed to provide SQS message id's so this PR is a proposed solution.

simply adds the possibility for messages to be objects of shape {id, body}.
i don't know what kind of messages you usually send but we send small JSON stringifed objects so using that as the id was a bit ugly..
there's maybe a bit too much 'error handling' for your liking.. 

let us know what you think.

cheers!