### PR TITLE
implement options validator + make options.region optional

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -24,7 +24,7 @@ function Producer(options) {
   this.queueUrl = options.queueUrl;
   this.batchSize = options.batchSize || 10;
   this.sqs = options.sqs || new AWS.SQS({
-    region: options.region
+    region: options.region || 'eu-west-1'
   });
 }
 

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -1,10 +1,28 @@
+'use strict';
+
 var AWS = require('aws-sdk');
 var selectn = require('selectn');
+var requiredOptions = [
+    'queueUrl'
+  ];
 
-var BATCH_SIZE = 10;
+function validate(options) {
+  requiredOptions.forEach(function (option) {
+    if (!options[option]) {
+      throw new Error('Missing SQS consumer option [' + option + '].');
+    }
+  });
+
+  if (options.batchSize > 10 || options.batchSize < 1) {
+    throw new Error('SQS batchSize option must be between 1 and 10.');
+  }
+}
 
 function Producer(options) {
+  validate(options);
+
   this.queueUrl = options.queueUrl;
+  this.batchSize = options.batchSize || 10;
   this.sqs = options.sqs || new AWS.SQS({
     region: options.region
   });
@@ -87,7 +105,7 @@ function createError(failedMessages) {
 
 Producer.prototype._sendBatch = function (failedMessages, messages, startIndex, cb) {
   var producer = this;
-  var endIndex = startIndex + BATCH_SIZE;
+  var endIndex = startIndex + this.batchSize;
   var batch = messages.slice(startIndex, endIndex);
   var params = {
     QueueUrl: this.queueUrl

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -150,7 +150,7 @@ Producer.prototype.queueSize = function (cb) {
     if (err) return cb(err);
 
     var size = selectn('Attributes.ApproximateNumberOfMessages', result);
-    cb(null, parseInt(size));
+    cb(null, parseInt(size, 10));
   });
 };
 


### PR DESCRIPTION
Options validator implementation has been retrieved in [sqs-consumer](https://github.com/james075/sqs-consumer/blob/master/index.js#L8-L36)

see also this [pull request](https://github.com/bbc/sqs-consumer/pull/3)