### PR TITLE
Fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ producer.send([
     id: 'id1',
     body: 'Hello world with two string attributes: attr1 and attr2',
     messageAttributes: {
-      attr1: { DataType: 'String', StringValue: 'stringValue' }
-      attr2: { DataType: 'BinaryValue', BinaryValue: new Buffer('binaryValue') }
+      attr1: { DataType: 'String', StringValue: 'stringValue' },
+      attr2: { DataType: 'Binary', BinaryValue: new Buffer('binaryValue') }
     }
   },
   {


### PR DESCRIPTION
Fix two typos in readme.

*DataType — required — (String)
Amazon SQS supports the following logical data types: String, Number, and `Binary`. In addition, you can append your own custom labels. For more information, see Message Attribute Data Types.

ref: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html