### PR TITLE
Support FIFO queue required params

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ producer.send([
   if (err) console.log(err);
 });
 
+// send a message to a FIFO queue
+//
+// note that AWS FIFO queues require two additional params:
+// - groupId (string)
+// - deduplicationId (string)
+//
+// deduplicationId can be excluded if content-based deduplication is enabled
+//
+// http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queue-recommendations.html
+producer.send({
+  body: 'Hello world from our FIFO queue!',
+  groupId: 'group1234',
+  deduplicationId: 'abcdef123456' // typically a hash of the message body
+}, function(err) {
+  if (err) console.log(err);
+});
 ```
 
 ## Test

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -75,6 +75,26 @@ function entryFromObject(message) {
     entry.MessageAttributes = message.messageAttributes;
   }
 
+  if (message.groupId) {
+    if (typeof message.groupId !== 'string') {
+      throw new Error('Message.groupId value must be a string');
+    }
+
+    entry.MessageGroupId = message.groupId;
+  }
+
+  if (message.deduplicationId) {
+    if (typeof message.deduplicationId !== 'string') {
+      throw new Error('Message.deduplicationId value must be a string');
+    }
+
+    entry.MessageDeduplicationId = message.deduplicationId;
+  }
+
+  if (entry.MessageDeduplicationId ^ entry.MessageGroupId) {
+    throw new Error('Both Message.groupId and Message.deduplicationId required for FIFO queues');
+  }
+
   return entry;
 }
 

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -91,10 +91,6 @@ function entryFromObject(message) {
     entry.MessageDeduplicationId = message.deduplicationId;
   }
 
-  if (entry.MessageDeduplicationId ^ entry.MessageGroupId) {
-    throw new Error('Both Message.groupId and Message.deduplicationId required for FIFO queues');
-  }
-
   return entry;
 }
 

--- a/test/producer.js
+++ b/test/producer.js
@@ -358,29 +358,6 @@ describe('Producer', function () {
       body: 'body1',
       deduplicationId: 1234
     };
-    var message2 = {
-      noId: 'noId2',
-      noBody: 'noBody2',
-    };
-
-    producer.send(['foo', message1, message2], function (err) {
-      assert.equal(err.message, errMessage);
-      done();
-    });
-  });
-
-  it('returns an error when object messages have either FIFO queue params but not both', function (done) {
-    var errMessage = 'Both Message.groupId and Message.deduplicationId required for FIFO queues';
-
-    var message1 = {
-      id: 'id1',
-      body: 'body1',
-      deduplicationId: '1234'
-    };
-    var message2 = {
-      noId: 'noId2',
-      noBody: 'noBody2',
-    };
 
     producer.send(['foo', message1, message2], function (err) {
       assert.equal(err.message, errMessage);

--- a/test/producer.js
+++ b/test/producer.js
@@ -339,12 +339,8 @@ describe('Producer', function () {
       body: 'body1',
       groupId: 1234
     };
-    var message2 = {
-      noId: 'noId2',
-      noBody: 'noBody2',
-    };
 
-    producer.send(['foo', message1, message2], function (err) {
+    producer.send(message1, function (err) {
       assert.equal(err.message, errMessage);
       done();
     });
@@ -359,7 +355,7 @@ describe('Producer', function () {
       deduplicationId: 1234
     };
 
-    producer.send(['foo', message1, message2], function (err) {
+    producer.send(message1, function (err) {
       assert.equal(err.message, errMessage);
       done();
     });

--- a/test/producer.js
+++ b/test/producer.js
@@ -143,18 +143,20 @@ describe('Producer', function () {
     });
   });
 
-  it('sends object messages with delaySeconds param as a batch', function (done) {
+  it('sends object messages with FIFO params as a batch', function (done) {
     var expectedParams = {
       Entries: [
         {
           Id: 'id1',
           MessageBody: 'body1',
-          DelaySeconds: 2
+          DelaySeconds: 2,
+          MessageGroupId: 'group1'
         },
         {
           Id: 'id2',
           MessageBody: 'body2',
-          DelaySeconds: 3
+          DelaySeconds: 3,
+          MessageGroupId: 'group2'
         }
       ],
       QueueUrl: queueUrl
@@ -163,12 +165,14 @@ describe('Producer', function () {
     var message1 = {
       id: 'id1',
       body: 'body1',
-      delaySeconds: 2
+      delaySeconds: 2,
+      groupId: 'group1'
     };
     var message2 = {
       id: 'id2',
       body: 'body2',
-      delaySeconds: 3
+      delaySeconds: 3,
+      groupId: 'group2'
     };
 
     producer.send([message1, message2], function (err) {
@@ -319,6 +323,63 @@ describe('Producer', function () {
     var message2 = {
       id: 'id2',
       body: 'body2'
+    };
+
+    producer.send(['foo', message1, message2], function (err) {
+      assert.equal(err.message, errMessage);
+      done();
+    });
+  });
+
+  it('returns an error when object messages have invalid queueId param', function (done) {
+    var errMessage = 'Message.groupId value must be a string';
+
+    var message1 = {
+      id: 'id1',
+      body: 'body1',
+      groupId: 1234
+    };
+    var message2 = {
+      noId: 'noId2',
+      noBody: 'noBody2',
+    };
+
+    producer.send(['foo', message1, message2], function (err) {
+      assert.equal(err.message, errMessage);
+      done();
+    });
+  });
+
+  it('returns an error when object messages have invalid deduplicationId param', function (done) {
+    var errMessage = 'Message.deduplicationId value must be a string';
+
+    var message1 = {
+      id: 'id1',
+      body: 'body1',
+      deduplicationId: 1234
+    };
+    var message2 = {
+      noId: 'noId2',
+      noBody: 'noBody2',
+    };
+
+    producer.send(['foo', message1, message2], function (err) {
+      assert.equal(err.message, errMessage);
+      done();
+    });
+  });
+
+  it('returns an error when object messages have either FIFO queue params but not both', function (done) {
+    var errMessage = 'Both Message.groupId and Message.deduplicationId required for FIFO queues';
+
+    var message1 = {
+      id: 'id1',
+      body: 'body1',
+      deduplicationId: '1234'
+    };
+    var message2 = {
+      noId: 'noId2',
+      noBody: 'noBody2',
     };
 
     producer.send(['foo', message1, message2], function (err) {


### PR DESCRIPTION
Use of FIFO queues requires `aws-sdk` v2.7.4+ but these changes shouldn't break any backwards compatibility.

### Coverage
```
=============================== Coverage summary ===============================
Statements   : 95.56% ( 86/90 )
Branches     : 87.27% ( 48/55 )
Functions    : 100% ( 16/16 )
Lines        : 96.59% ( 85/88 )
================================================================================
```