### PR TITLE
Forward configuration options to sqs

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -23,9 +23,9 @@ function Producer(options) {
 
   this.queueUrl = options.queueUrl;
   this.batchSize = options.batchSize || 10;
-  this.sqs = options.sqs || new AWS.SQS({
+  this.sqs = options.sqs || new AWS.SQS(Object.assign({}, options, {
     region: options.region || 'eu-west-1'
-  });
+  }));
 }
 
 function entryId(entry) {


### PR DESCRIPTION
Hey,

I was wondering if you'd be open to the following change?
This will allow us to use this library without having to rely on placing credentials in our file system. We use a configuration service in order to keep configuration and update it in real time, and thus find it difficult to rely on environment variables or filesystem configuration.
In this way, we'll simply pass the credentials to the AWS instance created by this producer without having to create it on our own and pass it.
What do you think?

(I did not add tests because I could not find any test cases for using the real sqs instance rather than the stubbed one).

Thanks! Let me know if you'd like me to change anything.,
