### PR TITLE
fix: don't require id for FIFO messages (Fixes #23)

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -59,7 +59,12 @@ function entryFromObject(message) {
     MessageBody: message.body
   };
     
-  if(message.id) entry.Id = message.id;
+  if(message.id) {
+    if (typeof message.id !== 'string') {
+      throw new Error('Message.id value must be a string');
+    }
+    entry.Id = message.id;
+  }
 
   if (message.delaySeconds) {
     if (

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -51,8 +51,8 @@ function entryFromObject(message) {
     throw new Error('Object messages must have \'id\' prop');
   }
     
-  if ((message.groupId && !message.deduplicationId) || (message.deduplicationId && !message.groupId)) {
-    throw new Error('FIFO Queue messages must have \'groupId\' and \'deduplicationId\' props');
+  if (message.deduplicationId && !message.groupId) {
+    throw new Error('FIFO Queue messages must have \'groupId\' prop');
   }
 
   var entry = {

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -56,9 +56,10 @@ function entryFromObject(message) {
   }
 
   var entry = {
-    Id: message.id || message.body,
     MessageBody: message.body
   };
+    
+  if(message.id) entry.Id = message.id;
 
   if (message.delaySeconds) {
     if (

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -43,13 +43,21 @@ function isMessageAttributeValid(messageAttribute) {
 }
 
 function entryFromObject(message) {
-  if (!message.id || !message.body) {
-    throw new Error('Object messages must have \'id\' and \'body\' props');
+  if (!message.body) {
+    throw new Error('Object messages must have \'body\' prop');
+  }
+    
+  if (!message.groupId && !message.deduplicationId && !message.id) {
+    throw new Error('Object messages must have \'id\' prop');
+  }
+    
+  if ((message.groupId && !message.deduplicationId) || (message.deduplicationId && !message.groupId)) {
+    throw new Error('FIFO Queue messages must have \'groupId\' and \'deduplicationId\' props');
   }
 
   var entry = {
-    Id: message.id,
-    MessageBody: message.body
+    MessageBody: message.body,
+    Id: message.id || message.body
   };
 
   if (message.delaySeconds) {

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -56,8 +56,8 @@ function entryFromObject(message) {
   }
 
   var entry = {
-    MessageBody: message.body,
-    Id: message.id || message.body
+    Id: message.id || message.body,
+    MessageBody: message.body
   };
 
   if (message.delaySeconds) {

--- a/test/producer.js
+++ b/test/producer.js
@@ -337,8 +337,7 @@ describe('Producer', function () {
     var message1 = {
       id: 'id1',
       body: 'body1',
-      groupId: 1234,
-      deduplicationId: '1234'
+      groupId: 1234
     };
 
     producer.send(message1, function (err) {
@@ -364,27 +363,12 @@ describe('Producer', function () {
   });
   
   it('returns an error when fifo messages have no groupId param', function (done) {
-    var errMessage = 'FIFO Queue messages must have \'groupId\' and \'deduplicationId\' props';
+    var errMessage = 'FIFO Queue messages must have \'groupId\' prop';
 
     var message1 = {
       id: 'id1',
       body: 'body1',
       deduplicationId: '1234'
-    };
-
-    producer.send(message1, function (err) {
-      assert.equal(err.message, errMessage);
-      done();
-    });
-  });
-
-  it('returns an error when fifo messages have no deduplicationId param', function (done) {
-    var errMessage = 'FIFO Queue messages must have \'groupId\' and \'deduplicationId\' props';
-
-    var message1 = {
-      id: 'id1',
-      body: 'body1',
-      groupId: '1234',
     };
 
     producer.send(message1, function (err) {

--- a/test/producer.js
+++ b/test/producer.js
@@ -331,13 +331,14 @@ describe('Producer', function () {
     });
   });
 
-  it('returns an error when object messages have invalid queueId param', function (done) {
+  it('returns an error when object messages have invalid groupId param', function (done) {
     var errMessage = 'Message.groupId value must be a string';
 
     var message1 = {
       id: 'id1',
       body: 'body1',
-      groupId: 1234
+      groupId: 1234,
+      deduplicationId: '1234'
     };
 
     producer.send(message1, function (err) {
@@ -352,7 +353,38 @@ describe('Producer', function () {
     var message1 = {
       id: 'id1',
       body: 'body1',
+      groupId: '1234',
       deduplicationId: 1234
+    };
+
+    producer.send(message1, function (err) {
+      assert.equal(err.message, errMessage);
+      done();
+    });
+  });
+  
+  it('returns an error when fifo messages have no groupId param', function (done) {
+    var errMessage = 'FIFO Queue messages must have \'groupId\' and \'deduplicationId\' props';
+
+    var message1 = {
+      id: 'id1',
+      body: 'body1',
+      deduplicationId: '1234'
+    };
+
+    producer.send(message1, function (err) {
+      assert.equal(err.message, errMessage);
+      done();
+    });
+  });
+
+  it('returns an error when fifo messages have no deduplicationId param', function (done) {
+    var errMessage = 'FIFO Queue messages must have \'groupId\' and \'deduplicationId\' props';
+
+    var message1 = {
+      id: 'id1',
+      body: 'body1',
+      groupId: '1234',
     };
 
     producer.send(message1, function (err) {
@@ -362,7 +394,7 @@ describe('Producer', function () {
   });
 
   it('returns an error when object messages are not of shape {id, body}', function (done) {
-    var errMessage = 'Object messages must have \'id\' and \'body\' props';
+    var errMessage = 'Object messages must have \'id\' prop';
 
     var message1 = {
       noId: 'noId1',
@@ -380,7 +412,7 @@ describe('Producer', function () {
   });
 
   it('returns an error when object messages are not of shape {id, body} 2', function (done) {
-    var errMessage = 'Object messages must have \'id\' and \'body\' props';
+    var errMessage = 'Object messages must have \'body\' prop';
 
     var message1 = {
       id: 'id1',
@@ -389,24 +421,6 @@ describe('Producer', function () {
     var message2 = {
       id: 'id2',
       body: 'body2'
-    };
-
-    producer.send(['foo', message1, message2], function (err) {
-      assert.equal(err.message, errMessage);
-      done();
-    });
-  });
-
-  it('returns an error when object messages are not of shape {id, body} 3', function (done) {
-    var errMessage = 'Object messages must have \'id\' and \'body\' props';
-
-    var message1 = {
-      id: 'id1',
-      body: 'body1'
-    };
-    var message2 = {
-      noId: 'noId2',
-      noBody: 'noBody2'
     };
 
     producer.send(['foo', message1, message2], function (err) {

--- a/test/producer.js
+++ b/test/producer.js
@@ -331,6 +331,20 @@ describe('Producer', function () {
     });
   });
 
+  it('returns an error when object messages have invalid id param', function (done) {
+    var errMessage = 'Message.id value must be a string';
+
+    var message1 = {
+      id: 1234,
+      body: 'body1'
+    };
+
+    producer.send(message1, function (err) {
+      assert.equal(err.message, errMessage);
+      done();
+    });
+  });
+  
   it('returns an error when object messages have invalid groupId param', function (done) {
     var errMessage = 'Message.groupId value must be a string';
 


### PR DESCRIPTION
According to the example in the docs, it isn't required.

If included, it should be used, if not, it should be the body.