### PR TITLE
Add message.Id as the index by default

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -42,7 +42,7 @@ function isMessageAttributeValid(messageAttribute) {
   return true;
 }
 
-function entryFromObject(message) {
+function entryFromObject(message, index) {
   if (!message.body) {
     throw new Error('Object messages must have \'body\' prop');
   }
@@ -56,10 +56,11 @@ function entryFromObject(message) {
   }
 
   var entry = {
-    MessageBody: message.body
+    MessageBody: message.body,
+    Id: index
   };
     
-  if(message.id) {
+  if (message.id) {
     if (typeof message.id !== 'string') {
       throw new Error('Message.id value must be a string');
     }
@@ -108,18 +109,18 @@ function entryFromObject(message) {
   return entry;
 }
 
-function entryFromString(message) {
+function entryFromString(message, index) {
   return {
-    Id: message,
+    Id: index,
     MessageBody: message
   };
 }
 
-function entryFromMessage(message) {
+function entryFromMessage(message, index) {
   if (typeof message === 'string') {
-    return entryFromString(message);
+    return entryFromString(message, index);
   } else if (typeof message === 'object') {
-    return entryFromObject(message);
+    return entryFromObject(message, index);
   }
 
   throw new Error('A message can either be an object or a string');

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -57,7 +57,7 @@ function entryFromObject(message, index) {
 
   var entry = {
     MessageBody: message.body,
-    Id: index
+    Id: index.toString()
   };
     
   if (message.id) {
@@ -111,7 +111,7 @@ function entryFromObject(message, index) {
 
 function entryFromString(message, index) {
   return {
-    Id: index,
+    Id: index.toString(),
     MessageBody: message
   };
 }

--- a/test/producer.js
+++ b/test/producer.js
@@ -29,7 +29,7 @@ describe('Producer', function () {
     var expectedParams = {
       Entries: [
         {
-          Id: 'message1',
+          Id: '0',
           MessageBody: 'message1'
         },
         {
@@ -52,7 +52,7 @@ describe('Producer', function () {
     var expectedParams = {
       Entries: [
         {
-          Id: 'message1',
+          Id: '0',
           MessageBody: 'message1'
         }
       ],
@@ -187,7 +187,7 @@ describe('Producer', function () {
     var expectedParams = {
       Entries: [
         {
-          Id: 'message1',
+          Id: '0',
           MessageBody: 'message1'
         },
         {

--- a/test/producer.js
+++ b/test/producer.js
@@ -33,7 +33,7 @@ describe('Producer', function () {
           MessageBody: 'message1'
         },
         {
-          Id: 'message2',
+          Id: '1',
           MessageBody: 'message2'
         }
       ],


### PR DESCRIPTION
As sqs-producer uses batch sending by default, Id is required. I had it in #24, but wrongly, this is a better fix.

Also, Id is limited to 80 alphanumeric chars, an entry from string which is larger than that would fail, this also fixes that.

