### PR TITLE
refacto(producer): queueUrl is now required the right way

### DIFF
--- a/src/producer.ts
+++ b/src/producer.ts
@@ -1,12 +1,9 @@
 import { SQS } from 'aws-sdk';
 import { SendMessageBatchResultEntryList } from 'aws-sdk/clients/sqs';
 import { Message, toEntry } from './types';
-const requiredOptions = [
-  'queueUrl'
-];
 
 interface ProducerOptions {
-  queueUrl?: string;
+  queueUrl: string;
   batchSize?: number;
   sqs?: SQS;
   region?: string;
@@ -48,11 +45,6 @@ export class Producer {
   }
 
   private validate(options: ProducerOptions): void {
-    for (const option of requiredOptions) {
-      if (!options[option]) {
-        throw new Error(`Missing SQS producer option [${option}].`);
-      }
-    }
     if (options.batchSize > 10 || options.batchSize < 1) {
       throw new Error('SQS batchSize option must be between 1 and 10.');
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
If queueUrl is required, then it should be directly in the ProducerOptions type, not in the validate method

<!--- Describe your changes in detail -->
## Motivation and Context
I think it cleaner that way 

<!--- Why is this change required? What problem does it solve? -->
The code is a little less complex

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
