### PR TITLE
update readme : create custom producer with accessKeyId / secretAccessKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm install sqs-producer
 
 ```js
 const { Producer } = require('sqs-producer');
+import AWS from 'aws-sdk'
 
 // create simple producer
 const producer = Producer.create({
@@ -25,11 +26,16 @@ const producer = Producer.create({
 });
 
 // create custom producer (supporting all opts as per the API docs: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#constructor-property)
+AWS.config.update({
+  accessKeyId: config.queue.aws_access_key_id,
+  secretAccessKey: config.queue.aws_secret_access_key,
+  region: 'eu-west-1',
+});
+
 const producer = Producer.create({
   queueUrl: 'https://sqs.eu-west-1.amazonaws.com/account-id/queue-name',
   region: 'eu-west-1',
-  accessKeyId: 'yourAccessKey',
-  secretAccessKey: 'yourSecret'
+  sqs: new AWS.SQS(),
 });
 
 // send messages to the queue

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ const producer = Producer.create({
 
 // create custom producer (supporting all opts as per the API docs: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#constructor-property)
 AWS.config.update({
-  accessKeyId: config.queue.aws_access_key_id,
-  secretAccessKey: config.queue.aws_secret_access_key,
+  accessKeyId: 'yourAccessKey',
+  secretAccessKey: 'yourSecret',
   region: 'eu-west-1',
 });
 


### PR DESCRIPTION
## Description
Update Readme.md 
- At Usage (create custom producer)
In the previous version of readme, use accessKeyId and secretAccessKey inside of parameter at Producer.create
but code implementation are doesn't use accessKeyId and secretAccessKey parameter.

So, I changed readme to use SQS parameter and AWS.config.update 

## Motivation and Context
 Based on Issue #63
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
