### PR TITLE
chore: Making queueurl required in interface

### DIFF
--- a/src/producer.ts
+++ b/src/producer.ts
@@ -8,7 +8,7 @@ import { Message, toEntry } from './types';
 const requiredOptions = ['queueUrl'];
 
 interface ProducerOptions {
-  queueUrl?: string;
+  queueUrl: string;
   batchSize?: number;
   sqs?: SQSClient;
   region?: string;


### PR DESCRIPTION
**Description:**

Queue URL is always a required option, but for some reason, this was made optional in the TypeScript interface.

This PR makes it required.