### PR TITLE
chore: changing node support level to min v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ npm install sqs-producer
 > npm install sqs-producer@2.2.0 --save-dev
 > ```
 
+### Node Version
+
+We will only support Node versions that are actively or security supported by the Node team. If you are still using an Node 14, please use a version of this library before the v3.2.1 release, if you are using Node 16, please use a version before the v3.3.0 release.
+
 ## Usage
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-producer",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Enqueues messages onto a given SQS queue",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,7 +20,7 @@
     "clean": "rm -fr dist/*"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #97

**Description:**

As a result of the security support  ending for Node v16 on September 11th, this PR sets the minimum supported version for Node to version 18.

After the release of this change, SQS Producer will only support Node versions 18 and 20.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

To ensure that we keep this library secure and at the latest expectations, we only support Node versions that are actively or security release supported.

**Code changes:**

- Updated the README
- Updated the workflows to remove Node 16
- Updated the Node version in package.json

---
