### PR TITLE
Attach failed message ids to error object

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,11 @@
+export class FailedMessagesError extends Error {
+  /** Ids of messages that failed to send. */
+  public failedMessages: string[];
+  /**
+   * @param failedMessages Ids of messages that failed to send.
+   */
+  constructor(failedMessages: string[]) {
+    super(`Failed to send messages: ${failedMessages.join(', ')}`);
+    this.failedMessages = failedMessages;
+  }
+}

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -6,6 +6,7 @@ import {
 } from '@aws-sdk/client-sqs';
 import { Message, ProducerOptions } from './types';
 import { toEntry } from './format';
+import { FailedMessagesError } from './errors';
 
 const requiredOptions = ['queueUrl'];
 
@@ -104,9 +105,7 @@ export class Producer {
     if (failedMessagesBatch.length === 0) {
       return successfulMessagesBatch;
     }
-    throw new Error(
-      `Failed to send messages: ${failedMessagesBatch.join(', ')}`
-    );
+    throw new FailedMessagesError(failedMessagesBatch);
   }
 }
 

--- a/test/producer.test.ts
+++ b/test/producer.test.ts
@@ -455,10 +455,16 @@ describe('Producer', () => {
       Failed: failedMessages
     });
 
-    await rejects(
-      producer.send(['message1', 'message2', 'message3']),
-      errMessage
-    );
+    try {
+      await producer.send(['message1', 'message2', 'message3']);
+      assert.fail('Should have thrown');
+    } catch (err) {
+      assert.equal(err.message, errMessage);
+      assert.deepEqual(
+        err.failedMessages,
+        failedMessages.map((m) => m.Id)
+      );
+    }
   });
 
   it('returns the approximate size of the queue', async () => {


### PR DESCRIPTION
**Description:**
Throw a custom error, when messages fail to send, with an additional property to expose the failed message ids for programmatic access.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
In cases where we have to take additional steps for the failed messages, we have to parse the error message in order to get their IDs.

**Code changes:**

- Add a custom `FailedMessagesError` error class, with a `failedMessages` property of type `string[]` to hold the IDs of the messages that failed to send.

---

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
