### PR TITLE
feat: updating ProducerOptions to use QueueUrl hostname

### DIFF
--- a/src/producer.ts
+++ b/src/producer.ts
@@ -20,6 +20,7 @@ export class Producer {
     this.validate(options);
     this.queueUrl = options.queueUrl;
     this.batchSize = options.batchSize || 10;
+    options.useQueueUrlAsEndpoint = options.useQueueUrlAsEndpoint ?? true;
     this.sqs =
       options.sqs ||
       new SQSClient({

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface ProducerOptions {
   batchSize?: number;
   sqs?: SQSClient;
   region?: string;
+  useQueueUrlAsEndpoint?: boolean;
 }
 
 export interface Message {


### PR DESCRIPTION
Resolves #NUMBER

**Description:**
_A very high-level summary of easily-reproducible changes that can be understood by non-devs._
Add useQueueUrlAsEndpoint support in Producer initialization
**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
_A simple explanation of what the problem is and how this PR solves it_
Let use QueueUrl hostname as the endpoint with [@aws-sdk/client-sqs@^v3.507.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.507.0) 
**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
