### PR TITLE
chore(deps): upgrading dependencies - march 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,30 +9,30 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sqs": "^3.507"
+        "@aws-sdk/client-sqs": "^3.529.1"
       },
       "devDependencies": {
-        "@types/chai": "^4.3.9",
-        "@types/debug": "^4.1.10",
-        "@types/mocha": "^10.0.3",
-        "@types/node": "^20.8.7",
-        "@types/sinon": "^10.0.20",
-        "c8": "^8.0.1",
-        "chai": "^4.3.10",
-        "eslint": "^8.52.0",
-        "eslint-config-iplayer": "^9.1.0",
-        "eslint-config-prettier": "^9.0.0",
-        "mocha": "^10.2.0",
-        "prettier": "^3.0.3",
-        "sinon": "^17.0.0",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.2.2"
+        "@types/chai": "^4.3.12",
+        "@types/debug": "^4.1.12",
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^20.11.25",
+        "@types/sinon": "^17.0.3",
+        "c8": "^9.1.0",
+        "chai": "^4.4.1",
+        "eslint": "^8.57.0",
+        "eslint-config-iplayer": "^9.2.0",
+        "eslint-config-prettier": "^9.1.0",
+        "mocha": "^10.3.0",
+        "prettier": "^3.2.5",
+        "sinon": "^17.0.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.2"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sqs": "^3.507"
+        "@aws-sdk/client-sqs": "^3.529.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -136,50 +136,50 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.507.0.tgz",
-      "integrity": "sha512-PYdJlj8dUoPPgxPdTGRe747FcvdPP7GQsVhXTBOMbSxTdxKX7Lo7W2Ky6Y7qZnlSgVwra5BEiu8I8iisp39+Uw==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.529.1.tgz",
+      "integrity": "sha512-TBQWhf/9tWw5b6xZ0l9TtQUyB8WVIOmS4t6enr6zWsf/MJ9rjEcGJh6gyoF71URL2Bv5/x7qzLVPzxT/NRE+Ag==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.507.0",
-        "@aws-sdk/core": "3.496.0",
-        "@aws-sdk/credential-provider-node": "3.507.0",
-        "@aws-sdk/middleware-host-header": "3.502.0",
-        "@aws-sdk/middleware-logger": "3.502.0",
-        "@aws-sdk/middleware-recursion-detection": "3.502.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.507.0",
-        "@aws-sdk/middleware-user-agent": "3.502.0",
-        "@aws-sdk/region-config-resolver": "3.502.0",
-        "@aws-sdk/types": "3.502.0",
-        "@aws-sdk/util-endpoints": "3.502.0",
-        "@aws-sdk/util-user-agent-browser": "3.502.0",
-        "@aws-sdk/util-user-agent-node": "3.502.0",
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/core": "^1.3.1",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/hash-node": "^2.1.1",
-        "@smithy/invalid-dependency": "^2.1.1",
-        "@smithy/md5-js": "^2.1.1",
-        "@smithy/middleware-content-length": "^2.1.1",
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
+        "@aws-sdk/client-sts": "3.529.1",
+        "@aws-sdk/core": "3.529.1",
+        "@aws-sdk/credential-provider-node": "3.529.1",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.525.0",
+        "@aws-sdk/middleware-user-agent": "3.525.0",
+        "@aws-sdk/region-config-resolver": "3.525.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.525.0",
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/core": "^1.3.5",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/md5-js": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
         "@smithy/util-base64": "^2.1.1",
         "@smithy/util-body-length-browser": "^2.1.1",
         "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.1",
-        "@smithy/util-defaults-mode-node": "^2.1.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.4",
+        "@smithy/util-defaults-mode-node": "^2.2.3",
+        "@smithy/util-endpoints": "^1.1.4",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
         "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
@@ -188,45 +188,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.507.0.tgz",
-      "integrity": "sha512-pFeaKwqv4tXD6QVxWC2V4N62DUoP3bPSm/mCe2SPhaNjNsmwwA53viUHz/nwxIbs8w4vV44UQsygb0AgKm+HoQ==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.529.1.tgz",
+      "integrity": "sha512-KT1U/ZNjDhVv2ZgjzaeAn9VM7l667yeSguMrRYC8qk5h91/61MbjZypi6eOuKuVM+0fsQvzKScTQz0Lio0eYag==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.496.0",
-        "@aws-sdk/middleware-host-header": "3.502.0",
-        "@aws-sdk/middleware-logger": "3.502.0",
-        "@aws-sdk/middleware-recursion-detection": "3.502.0",
-        "@aws-sdk/middleware-user-agent": "3.502.0",
-        "@aws-sdk/region-config-resolver": "3.502.0",
-        "@aws-sdk/types": "3.502.0",
-        "@aws-sdk/util-endpoints": "3.502.0",
-        "@aws-sdk/util-user-agent-browser": "3.502.0",
-        "@aws-sdk/util-user-agent-node": "3.502.0",
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/core": "^1.3.1",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/hash-node": "^2.1.1",
-        "@smithy/invalid-dependency": "^2.1.1",
-        "@smithy/middleware-content-length": "^2.1.1",
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
+        "@aws-sdk/core": "3.529.1",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.525.0",
+        "@aws-sdk/region-config-resolver": "3.525.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.525.0",
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/core": "^1.3.5",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
         "@smithy/util-base64": "^2.1.1",
         "@smithy/util-body-length-browser": "^2.1.1",
         "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.1",
-        "@smithy/util-defaults-mode-node": "^2.1.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.4",
+        "@smithy/util-defaults-mode-node": "^2.2.3",
+        "@smithy/util-endpoints": "^1.1.4",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
         "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
@@ -235,47 +236,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.507.0.tgz",
-      "integrity": "sha512-ms5CH2ImhqqCIbo5irxayByuPOlVAmSiqDVfjZKwgIziqng2bVgNZMeKcT6t0bmrcgScEAVnZwY7j/iZTIw73g==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.529.1.tgz",
+      "integrity": "sha512-bimxCWAvRnVcluWEQeadXvHyzWlBWsuGVligsaVZaGF0TLSn0eLpzpN9B1EhHzTf7m0Kh/wGtPSH1JxO6PpB+A==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.507.0",
-        "@aws-sdk/core": "3.496.0",
-        "@aws-sdk/middleware-host-header": "3.502.0",
-        "@aws-sdk/middleware-logger": "3.502.0",
-        "@aws-sdk/middleware-recursion-detection": "3.502.0",
-        "@aws-sdk/middleware-signing": "3.502.0",
-        "@aws-sdk/middleware-user-agent": "3.502.0",
-        "@aws-sdk/region-config-resolver": "3.502.0",
-        "@aws-sdk/types": "3.502.0",
-        "@aws-sdk/util-endpoints": "3.502.0",
-        "@aws-sdk/util-user-agent-browser": "3.502.0",
-        "@aws-sdk/util-user-agent-node": "3.502.0",
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/core": "^1.3.1",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/hash-node": "^2.1.1",
-        "@smithy/invalid-dependency": "^2.1.1",
-        "@smithy/middleware-content-length": "^2.1.1",
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
+        "@aws-sdk/client-sts": "3.529.1",
+        "@aws-sdk/core": "3.529.1",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.525.0",
+        "@aws-sdk/region-config-resolver": "3.525.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.525.0",
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/core": "^1.3.5",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
         "@smithy/util-base64": "^2.1.1",
         "@smithy/util-body-length-browser": "^2.1.1",
         "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.1",
-        "@smithy/util-defaults-mode-node": "^2.1.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.4",
+        "@smithy/util-defaults-mode-node": "^2.2.3",
+        "@smithy/util-endpoints": "^1.1.4",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
         "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
@@ -283,71 +284,71 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-provider-node": "^3.507.0"
+        "@aws-sdk/credential-provider-node": "^3.529.1"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.507.0.tgz",
-      "integrity": "sha512-TOWBe0ApEh32QOib0R+irWGjd1F9wnhbGV5PcB9SakyRwvqwG5MKOfYxG7ocoDqLlaRwzZMidcy/PV8/OEVNKg==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.529.1.tgz",
+      "integrity": "sha512-Rvk2Sr3MACQTOtngUU+omlf4E17k47dRVXR7OFRD6Ow5iGgC9tkN2q/ExDPW/ktPOmM0lSgzWyQ6/PC/Zq3HUg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.496.0",
-        "@aws-sdk/middleware-host-header": "3.502.0",
-        "@aws-sdk/middleware-logger": "3.502.0",
-        "@aws-sdk/middleware-recursion-detection": "3.502.0",
-        "@aws-sdk/middleware-user-agent": "3.502.0",
-        "@aws-sdk/region-config-resolver": "3.502.0",
-        "@aws-sdk/types": "3.502.0",
-        "@aws-sdk/util-endpoints": "3.502.0",
-        "@aws-sdk/util-user-agent-browser": "3.502.0",
-        "@aws-sdk/util-user-agent-node": "3.502.0",
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/core": "^1.3.1",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/hash-node": "^2.1.1",
-        "@smithy/invalid-dependency": "^2.1.1",
-        "@smithy/middleware-content-length": "^2.1.1",
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
+        "@aws-sdk/core": "3.529.1",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.525.0",
+        "@aws-sdk/region-config-resolver": "3.525.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.525.0",
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/core": "^1.3.5",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
         "@smithy/util-base64": "^2.1.1",
         "@smithy/util-body-length-browser": "^2.1.1",
         "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.1",
-        "@smithy/util-defaults-mode-node": "^2.1.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.4",
+        "@smithy/util-defaults-mode-node": "^2.2.3",
+        "@smithy/util-endpoints": "^1.1.4",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
         "@smithy/util-utf8": "^2.1.1",
-        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-provider-node": "^3.507.0"
+        "@aws-sdk/credential-provider-node": "^3.529.1"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
-      "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.529.1.tgz",
+      "integrity": "sha512-Sj42sYPfaL9PHvvciMICxhyrDZjqnnvFbPKDmQL5aFKyXy122qx7RdVqUOQERDmMQfvJh6+0W1zQlLnre89q4Q==",
       "dependencies": {
-        "@smithy/core": "^1.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/signature-v4": "^2.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
+        "@smithy/core": "^1.3.5",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/signature-v4": "^2.1.3",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -355,13 +356,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.502.0.tgz",
-      "integrity": "sha512-KIB8Ae1Z7domMU/jU4KiIgK4tmYgvuXlhR54ehwlVHxnEoFPoPuGHFZU7oFn79jhhSLUFQ1lRYMxP0cEwb7XeQ==",
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.523.0.tgz",
+      "integrity": "sha512-Y6DWdH6/OuMDoNKVzZlNeBc6f1Yjk1lYMjANKpIhMbkRCvLJw/PYZKOZa8WpXbTYdgg9XLjKybnLIb3ww3uuzA==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -369,18 +370,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.503.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.503.1.tgz",
-      "integrity": "sha512-rTdlFFGoPPFMF2YjtlfRuSgKI+XsF49u7d98255hySwhsbwd3Xp+utTTPquxP+CwDxMHbDlI7NxDzFiFdsoZug==",
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.525.0.tgz",
+      "integrity": "sha512-RNWQGuSBQZhl3iqklOslUEfQ4br1V3DCPboMpeqFtddUWJV3m2u2extFur9/4Uy+1EHVF120IwZUKtd8dF+ibw==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-stream": "^2.1.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-stream": "^2.1.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -388,20 +389,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.507.0.tgz",
-      "integrity": "sha512-2CnyduoR9COgd7qH1LPYK8UggGqVs8R4ASDMB5bwGxbg9ZerlStDiHpqvJNNg1k+VlejBr++utxfmHd236XgmQ==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.529.1.tgz",
+      "integrity": "sha512-RjHsuTvHIwXG7a/3ERexemiD3c9riKMCZQzY2/b0Gg0ButEVbBcMfERtUzWmQ0V4ufe/PEZjP68MH1gupcoF9A==",
       "dependencies": {
-        "@aws-sdk/client-sts": "3.507.0",
-        "@aws-sdk/credential-provider-env": "3.502.0",
-        "@aws-sdk/credential-provider-process": "3.502.0",
-        "@aws-sdk/credential-provider-sso": "3.507.0",
-        "@aws-sdk/credential-provider-web-identity": "3.507.0",
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/credential-provider-imds": "^2.2.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/client-sts": "3.529.1",
+        "@aws-sdk/credential-provider-env": "3.523.0",
+        "@aws-sdk/credential-provider-process": "3.523.0",
+        "@aws-sdk/credential-provider-sso": "3.529.1",
+        "@aws-sdk/credential-provider-web-identity": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/credential-provider-imds": "^2.2.3",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -409,21 +410,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.507.0.tgz",
-      "integrity": "sha512-tkQnmOLkRBXfMLgDYHzogrqTNdtl0Im0ipzJb2IV5hfM5NoTfCf795e9A9isgwjSP/g/YEU0xQWxa4lq8LRtuA==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.529.1.tgz",
+      "integrity": "sha512-mvY7F3dMmk/0dZOCfl5sUI1bG0osureBjxhELGCF0KkJqhWI0hIzh8UnPkYytSg3vdc97CMv7pTcozxrdA3b0g==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.502.0",
-        "@aws-sdk/credential-provider-http": "3.503.1",
-        "@aws-sdk/credential-provider-ini": "3.507.0",
-        "@aws-sdk/credential-provider-process": "3.502.0",
-        "@aws-sdk/credential-provider-sso": "3.507.0",
-        "@aws-sdk/credential-provider-web-identity": "3.507.0",
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/credential-provider-imds": "^2.2.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/credential-provider-env": "3.523.0",
+        "@aws-sdk/credential-provider-http": "3.525.0",
+        "@aws-sdk/credential-provider-ini": "3.529.1",
+        "@aws-sdk/credential-provider-process": "3.523.0",
+        "@aws-sdk/credential-provider-sso": "3.529.1",
+        "@aws-sdk/credential-provider-web-identity": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/credential-provider-imds": "^2.2.3",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -431,14 +432,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.502.0.tgz",
-      "integrity": "sha512-fJJowOjQ4infYQX0E1J3xFVlmuwEYJAFk0Mo1qwafWmEthsBJs+6BR2RiWDELHKrSK35u4Pf3fu3RkYuCtmQFw==",
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.523.0.tgz",
+      "integrity": "sha512-f0LP9KlFmMvPWdKeUKYlZ6FkQAECUeZMmISsv6NKtvPCI9e4O4cLTeR09telwDK8P0HrgcRuZfXM7E30m8re0Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -446,16 +447,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.507.0.tgz",
-      "integrity": "sha512-6WBjou52QukFpDi4ezb19bcAx/bM8ge8qnJnRT02WVRmU6zFQ5yLD2fW1MFsbX3cwbey+wSqKd5FGE1Hukd5wQ==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.529.1.tgz",
+      "integrity": "sha512-KFMKkaoTGDgSJG+o9Ii7AglWG5JQeF6IFw9cXLMwDdIrp3KUmRcUIqe0cjOoCqeQEDGy0VHsimHmKKJ3894i/A==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.507.0",
-        "@aws-sdk/token-providers": "3.507.0",
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/client-sso": "3.529.1",
+        "@aws-sdk/token-providers": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -463,14 +464,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.507.0.tgz",
-      "integrity": "sha512-f+aGMfazBimX7S06224JRYzGTaMh1uIhfj23tZylPJ05KxTVi5IO1RoqeI/uHLJ+bDOx+JHBC04g/oCdO4kHvw==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.529.1.tgz",
+      "integrity": "sha512-AGuZDOKN+AttjwTjrF47WLqzeEut2YynyxjkXZhxZF/xn8i5Y51kUAUdXsXw1bgR25pAeXQIdhsrQlRa1Pm5kw==",
       "dependencies": {
-        "@aws-sdk/client-sts": "3.507.0",
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/client-sts": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -478,13 +479,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.502.0.tgz",
-      "integrity": "sha512-EjnG0GTYXT/wJBmm5/mTjDcAkzU8L7wQjOzd3FTXuTCNNyvAvwrszbOj5FlarEw5XJBbQiZtBs+I5u9+zy560w==",
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.523.0.tgz",
+      "integrity": "sha512-4g3q7Ta9sdD9TMUuohBAkbx/e3I/juTqfKi7TPgP+8jxcYX72MOsgemAMHuP6CX27eyj4dpvjH+w4SIVDiDSmg==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -492,12 +493,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.502.0.tgz",
-      "integrity": "sha512-FDyv6K4nCoHxbjLGS2H8ex8I0KDIiu4FJgVRPs140ZJy6gE5Pwxzv6YTzZGLMrnqcIs9gh065Lf6DjwMelZqaw==",
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.523.0.tgz",
+      "integrity": "sha512-PeDNJNhfiaZx54LBaLTXzUaJ9LXFwDFFIksipjqjvxMafnoVcQwKbkoPUWLe5ytT4nnL1LogD3s55mERFUsnwg==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -505,13 +506,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.502.0.tgz",
-      "integrity": "sha512-hvbyGJbxeuezxOu8VfFmcV4ql1hKXLxHTe5FNYfEBat2KaZXVhc1Hg+4TvB06/53p+E8J99Afmumkqbxs2esUA==",
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.523.0.tgz",
+      "integrity": "sha512-nZ3Vt7ehfSDYnrcg/aAfjjvpdE+61B3Zk68i6/hSUIegT3IH9H1vSW67NDKVp+50hcEfzWwM2HMPXxlzuyFyrw==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -519,13 +520,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.507.0.tgz",
-      "integrity": "sha512-6D4FvN7iRMmYo6r1mQ9cZVJSHzzNRaTxmXiWBv/6oS59hoS2CtjzsiMH2Ab2fyiBCtmksiLbCfwoz1E5VifZHw==",
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.525.0.tgz",
+      "integrity": "sha512-w+H1VOajANjo5gxe2/rQjO7HEuIiEyuFNZzNsztH1E9JBZ01Z2EvEYAfZTkCOV40Or4I2lTHnyt9voXIxW+bzw==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
         "@smithy/util-hex-encoding": "^2.1.1",
         "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
@@ -534,32 +535,15 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.502.0.tgz",
-      "integrity": "sha512-4hF08vSzJ7L6sB+393gOFj3s2N6nLusYS0XrMW6wYNFU10IDdbf8Z3TZ7gysDJJHEGQPmTAesPEDBsasGWcMxg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/signature-v4": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.502.0.tgz",
-      "integrity": "sha512-TxbBZbRiXPH0AUxegqiNd9aM9zNSbfjtBs5MEfcBsweeT/B2O7K1EjP9+CkB8Xmk/5FLKhAKLr19b1TNoE27rw==",
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.525.0.tgz",
+      "integrity": "sha512-4al/6uO+t/QIYXK2OgqzDKQzzLAYJza1vWFS+S0lJ3jLNGyLB5BMU5KqWjDzevYZ4eCnz2Nn7z0FveUTNz8YdQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@aws-sdk/util-endpoints": "3.502.0",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -567,15 +551,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.502.0.tgz",
-      "integrity": "sha512-mxmsX2AGgnSM+Sah7mcQCIneOsJQNiLX0COwEttuf8eO+6cLMAZvVudH3BnWTfea4/A9nuri9DLCqBvEmPrilg==",
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.525.0.tgz",
+      "integrity": "sha512-8kFqXk6UyKgTMi7N7QlhA6qM4pGPWbiUXqEY2RgUWngtxqNFGeM9JTexZeuavQI+qLLe09VPShPNX71fEDcM6w==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/types": "^2.10.1",
         "@smithy/util-config-provider": "^2.2.1",
-        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -583,15 +567,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.507.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.507.0.tgz",
-      "integrity": "sha512-ehOINGjoGJc6Puzon7ev4bXckkaZx18WNgMTNttYJhj3vTpj5LPSQbI/5SS927bEbpGMFz1+hJ6Ra5WGfbTcEQ==",
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.529.1.tgz",
+      "integrity": "sha512-NpgMjsfpqiugbxrYGXtta914N43Mx/H0niidqv8wKMTgWQEtsJvYtOni+kuLXB+LmpjaMFNlpadooFU/bK4buA==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.507.0",
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/client-sso-oidc": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -599,11 +583,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
-      "integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -611,13 +595,13 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.502.0.tgz",
-      "integrity": "sha512-6LKFlJPp2J24r1Kpfoz5ESQn+1v5fEjDB3mtUKRdpwarhm3syu7HbKlHCF3KbcCOyahobvLvhoedT78rJFEeeg==",
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.525.0.tgz",
+      "integrity": "sha512-DIW7WWU5tIGkeeKX6NJUyrEIdWMiqjLQG3XBzaUj+ufIENwNjdAHhlD8l2vX7Yr3JZRT6yN/84wBCj7Tw1xd1g==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-endpoints": "^1.1.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-endpoints": "^1.1.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -636,24 +620,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.502.0.tgz",
-      "integrity": "sha512-v8gKyCs2obXoIkLETAeEQ3AM+QmhHhst9xbM1cJtKUGsRlVIak/XyyD+kVE6kmMm1cjfudHpHKABWk9apQcIZQ==",
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.523.0.tgz",
+      "integrity": "sha512-6ZRNdGHX6+HQFqTbIA5+i8RWzxFyxsZv8D3soRfpdyWIKkzhSz8IyRKXRciwKBJDaC7OX2jzGE90wxRQft27nA==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.502.0.tgz",
-      "integrity": "sha512-9RjxpkGZKbTdl96tIJvAo+vZoz4P/cQh36SBUt9xfRfW0BtsaLyvSrvlR5wyUYhvRcC12Axqh/8JtnAPq//+Vw==",
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.525.0.tgz",
+      "integrity": "sha512-88Wjt4efyUSBGcyIuh1dvoMqY1k15jpJc5A/3yi67clBQEFsu9QCodQCQPqmRjV3VRcMtBOk+jeCTiUzTY5dRQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -729,9 +713,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -752,22 +736,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -788,9 +772,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
     "node_modules/@istanbuljs/schema": {
@@ -913,11 +897,11 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
-      "integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.4.tgz",
+      "integrity": "sha512-66HO817oIZ2otLIqy06R5muapqZjkgF1jfU0wyNko8cuqZNu8nbS9ljlhcRYw/M/uWRJzB9ih81DLSHhYbBLlQ==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -925,14 +909,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.4.tgz",
-      "integrity": "sha512-AW2WUZmBAzgO3V3ovKtsUbI3aBNMeQKFDumoqkNxaVDWF/xfnxAWqBKDr/NuG7c06N2Rm4xeZLPiJH/d+na0HA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.5.tgz",
+      "integrity": "sha512-LcBB5JQC3Tx2ZExIJzfvWaajhFIwHrUNQeqxhred2r5nnqrdly9uoCrvM1sxOOdghYuWWm2Kr8tBCDOmxsgeTA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/types": "^2.10.1",
+        "@smithy/node-config-provider": "^2.2.5",
+        "@smithy/types": "^2.11.0",
         "@smithy/util-config-provider": "^2.2.1",
-        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-middleware": "^2.1.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -940,17 +924,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.5.tgz",
-      "integrity": "sha512-Rrc+e2Jj6Gu7Xbn0jvrzZlSiP2CZocIOfZ9aNUA82+1sa6GBnxqL9+iZ9EKHeD9aqD1nU8EK4+oN2EiFpSv7Yw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.7.tgz",
+      "integrity": "sha512-zHrrstOO78g+/rOJoHi4j3mGUBtsljRhcKNzloWPv1XIwgcFUi+F1YFKr2qPQ3z7Ls5dNc4L2SPrVarNFIQqog==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.6",
+        "@smithy/middleware-retry": "^2.1.6",
+        "@smithy/middleware-serde": "^2.2.1",
+        "@smithy/protocol-http": "^3.2.2",
+        "@smithy/smithy-client": "^2.4.4",
+        "@smithy/types": "^2.11.0",
+        "@smithy/util-middleware": "^2.1.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -958,14 +942,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.5.tgz",
-      "integrity": "sha512-OxgD7jX6bjDJNYsjKCZN+PBVy3ZNiXGhysOtfaV1+WGSmbJJWkw613BQaY0iDAxVxUNTt30Lt3NyhimAAsZ3TA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.6.tgz",
+      "integrity": "sha512-+xQe4Pite0kdk9qn0Vyw5BRVh0iSlj+T4TEKRXr4E1wZKtVgIzGlkCrfICSjiPVFkPxk4jMpVboMYdEiiA88/w==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.5",
+        "@smithy/property-provider": "^2.1.4",
+        "@smithy/types": "^2.11.0",
+        "@smithy/url-parser": "^2.1.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -973,36 +957,36 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
-      "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.4.tgz",
+      "integrity": "sha512-UkiieTztP7adg8EuqZvB0Y4LewdleZCJU7Kgt9RDutMsRYqO32fMpWeQHeTHaIMosmzcRZUykMRrhwGJe9mP3A==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "@smithy/util-hex-encoding": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.3.tgz",
-      "integrity": "sha512-Fn/KYJFo6L5I4YPG8WQb2hOmExgRmNpVH5IK2zU3JKrY5FKW7y9ar5e0BexiIC9DhSKqKX+HeWq/Y18fq7Dkpw==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.4.tgz",
+      "integrity": "sha512-DSUtmsnIx26tPuyyrK49dk2DAhPgEw6xRW7V62nMHIB5dk3NqhGnwcKO2fMdt/l3NUVgia34ZsSJA8bD+3nh7g==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/querystring-builder": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-base64": "^2.1.1",
+        "@smithy/protocol-http": "^3.2.2",
+        "@smithy/querystring-builder": "^2.1.4",
+        "@smithy/types": "^2.11.0",
+        "@smithy/util-base64": "^2.2.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.3.tgz",
-      "integrity": "sha512-FsAPCUj7VNJIdHbSxMd5uiZiF20G2zdSDgrgrDrHqIs/VMxK85Vqk5kMVNNDMCZmMezp6UKnac0B4nAyx7HJ9g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.4.tgz",
+      "integrity": "sha512-uvCcpDLXaTTL0X/9ezF8T8sS77UglTfZVQaUOBiCvR0QydeSyio3t0Hj3QooVdyFsKTubR8gCk/ubLk3vAyDng==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
+        "@smithy/util-utf8": "^2.2.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1010,11 +994,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.3.tgz",
-      "integrity": "sha512-wkra7d/G4CbngV4xsjYyAYOvdAhahQje/WymuQdVEnXFExJopEu7fbL5AEAlBPgWHXwu94VnCSG00gVzRfExyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.4.tgz",
+      "integrity": "sha512-QzlNBl6jt3nb9jNnE51wTegReVvUdozyMMrFEyb/rc6AzPID1O+qMJYjAAoNw098y0CZVfCpEnoK2+mfBOd8XA==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
@@ -1040,12 +1024,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.3.tgz",
-      "integrity": "sha512-aJduhkC+dcXxdnv5ZpM3uMmtGmVFKx412R1gbeykS5HXDmRU6oSsyy2SoHENCkfOGKAQOjVE2WVqDJibC0d21g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.4.tgz",
+      "integrity": "sha512-C6VRwfcr0w9qRFhDGCpWMVhlEIBFlmlPRP1aX9Cv9xDj9SUwlDrNvoV1oP1vjRYuLxCDgovBBynCwwcluS2wLw==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
+        "@smithy/protocol-http": "^3.2.2",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1053,16 +1037,16 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.4.tgz",
-      "integrity": "sha512-4yjHyHK2Jul4JUDBo2sTsWY9UshYUnXeb/TAK/MTaPEb8XQvDmpwSFnfIRDU45RY1a6iC9LCnmJNg/yHyfxqkw==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.6.tgz",
+      "integrity": "sha512-AsXtUXHPOAS0EGZUSFOsVJvc7p0KL29PGkLxLfycPOcFVLru/oinYB6yvyL73ZZPX2OB8sMYUMrj7eH2kI7V/w==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/shared-ini-file-loader": "^2.3.4",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/middleware-serde": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.5",
+        "@smithy/shared-ini-file-loader": "^2.3.5",
+        "@smithy/types": "^2.11.0",
+        "@smithy/url-parser": "^2.1.4",
+        "@smithy/util-middleware": "^2.1.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1070,17 +1054,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.4.tgz",
-      "integrity": "sha512-Cyolv9YckZTPli1EkkaS39UklonxMd08VskiuMhURDjC0HHa/AD6aK/YoD21CHv9s0QLg0WMLvk9YeLTKkXaFQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.6.tgz",
+      "integrity": "sha512-khpSV0NxqMHfa06kfG4WYv+978sVvfTFmn0hIFKKwOXtIxyYtPKiQWFT4nnwZD07fGdYGbtCBu3YALc8SsA5mA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/service-error-classification": "^2.1.3",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-middleware": "^2.1.3",
-        "@smithy/util-retry": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.5",
+        "@smithy/protocol-http": "^3.2.2",
+        "@smithy/service-error-classification": "^2.1.4",
+        "@smithy/smithy-client": "^2.4.4",
+        "@smithy/types": "^2.11.0",
+        "@smithy/util-middleware": "^2.1.4",
+        "@smithy/util-retry": "^2.1.4",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -1089,11 +1073,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.3.tgz",
-      "integrity": "sha512-s76LId+TwASrHhUa9QS4k/zeXDUAuNuddKklQzRgumbzge5BftVXHXIqL4wQxKGLocPwfgAOXWx+HdWhQk9hTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.2.1.tgz",
+      "integrity": "sha512-VAWRWqnNjgccebndpyK94om4ZTYzXLQxUmNCXYzM/3O9MTfQjTNBgtFtQwyIIez6z7LWcCsXmnKVIOE9mLqAHQ==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1101,11 +1085,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.3.tgz",
-      "integrity": "sha512-opMFufVQgvBSld/b7mD7OOEBxF6STyraVr1xel1j0abVILM8ALJvRoFbqSWHGmaDlRGIiV9Q5cGbWi0sdiEaLQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.4.tgz",
+      "integrity": "sha512-Qqs2ba8Ax1rGKOSGJS2JN23fhhox2WMdRuzx0NYHtXzhxbJOIMmz9uQY6Hf4PY8FPteBPp1+h0j5Fmr+oW12sg==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1113,13 +1097,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
-      "integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.5.tgz",
+      "integrity": "sha512-CxPf2CXhjO79IypHJLBATB66Dw6suvr1Yc2ccY39hpR6wdse3pZ3E8RF83SODiNH0Wjmkd0ze4OF8exugEixgA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.4",
-        "@smithy/types": "^2.10.1",
+        "@smithy/property-provider": "^2.1.4",
+        "@smithy/shared-ini-file-loader": "^2.3.5",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1127,14 +1111,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.1.tgz",
-      "integrity": "sha512-HCkb94soYhJMxPCa61wGKgmeKpJ3Gftx1XD6bcWEB2wMV1L9/SkQu/6/ysKBnbOzWRE01FGzwrTxucHypZ8rdg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.2.tgz",
+      "integrity": "sha512-yrj3c1g145uiK5io+1UPbJAHo8BSGORkBzrmzvAsOmBKb+1p3jmM8ZwNLDH/HTTxVLm9iM5rMszx+iAh1HUC4Q==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.1.3",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/querystring-builder": "^2.1.3",
-        "@smithy/types": "^2.10.1",
+        "@smithy/abort-controller": "^2.1.4",
+        "@smithy/protocol-http": "^3.2.2",
+        "@smithy/querystring-builder": "^2.1.4",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1142,11 +1126,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
-      "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.4.tgz",
+      "integrity": "sha512-nWaY/MImj1BiXZ9WY65h45dcxOx8pl06KYoHxwojDxDL+Q9yLU1YnZpgv8zsHhEftlj9KhePENjQTlNowWVyug==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1154,11 +1138,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-      "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.2.tgz",
+      "integrity": "sha512-xYBlllOQcOuLoxzhF2u8kRHhIFGQpDeTQj/dBSnw4kfI29WMKL5RnW1m9YjnJAJ49miuIvrkJR+gW5bCQ+Mchw==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1166,11 +1150,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.3.tgz",
-      "integrity": "sha512-kFD3PnNqKELe6m9GRHQw/ftFFSZpnSeQD4qvgDB6BQN6hREHELSosVFUMPN4M3MDKN2jAwk35vXHLoDrNfKu0A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.4.tgz",
+      "integrity": "sha512-LXSL0J/nRWvGT+jIj+Fip3j0J1ZmHkUyBFRzg/4SmPNCLeDrtVu7ptKOnTboPsFZu5BxmpYok3kJuQzzRdrhbw==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "@smithy/util-uri-escape": "^2.1.1",
         "tslib": "^2.5.0"
       },
@@ -1179,11 +1163,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.3.tgz",
-      "integrity": "sha512-3+CWJoAqcBMR+yvz6D+Fc5VdoGFtfenW6wqSWATWajrRMGVwJGPT3Vy2eb2bnMktJc4HU4bpjeovFa566P3knQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.4.tgz",
+      "integrity": "sha512-U2b8olKXgZAs0eRo7Op11jTNmmcC/sqYmsA7vN6A+jkGnDvJlEl7AetUegbBzU8q3D6WzC5rhR/joIy8tXPzIg==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1191,22 +1175,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.3.tgz",
-      "integrity": "sha512-iUrpSsem97bbXHHT/v3s7vaq8IIeMo6P6cXdeYHrx0wOJpMeBGQF7CB0mbJSiTm3//iq3L55JiEm8rA7CTVI8A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.4.tgz",
+      "integrity": "sha512-JW2Hthy21evnvDmYYk1kItOmbp3X5XI5iqorXgFEunb6hQfSDZ7O1g0Clyxg7k/Pcr9pfLk5xDIR2To/IohlsQ==",
       "dependencies": {
-        "@smithy/types": "^2.10.1"
+        "@smithy/types": "^2.11.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
-      "integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.5.tgz",
+      "integrity": "sha512-oI99+hOvsM8oAJtxAGmoL/YCcGXtbP0fjPseYGaNmJ4X5xOFTer0KPk7AIH3AL6c5AlYErivEi1X/X78HgTVIw==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1214,17 +1198,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
-      "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.4.tgz",
+      "integrity": "sha512-gnu9gCn0qQ8IdhNjs6o3QVCXzUs33znSDYwVMWo3nX4dM6j7z9u6FC302ShYyVWfO4MkVMuGCCJ6nl3PcH7V1Q==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.1.3",
+        "@smithy/eventstream-codec": "^2.1.4",
         "@smithy/is-array-buffer": "^2.1.1",
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "@smithy/util-hex-encoding": "^2.1.1",
-        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-middleware": "^2.1.4",
         "@smithy/util-uri-escape": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
+        "@smithy/util-utf8": "^2.2.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1232,15 +1216,15 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.2.tgz",
-      "integrity": "sha512-ntAFYN51zu3N3mCd95YFcFi/8rmvm//uX+HnK24CRbI6k5Rjackn0JhgKz5zOx/tbNvOpgQIwhSX+1EvEsBLbA==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.4.tgz",
+      "integrity": "sha512-SNE17wjycPZIJ2P5sv6wMTteV/vQVPdaqQkoK1KeGoWHXx79t3iLhQXj1uqRdlkMUS9pXJrLOAS+VvUSOYwQKw==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-stream": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.6",
+        "@smithy/middleware-stack": "^2.1.4",
+        "@smithy/protocol-http": "^3.2.2",
+        "@smithy/types": "^2.11.0",
+        "@smithy/util-stream": "^2.1.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1248,9 +1232,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.11.0.tgz",
+      "integrity": "sha512-AR0SXO7FuAskfNhyGfSTThpLRntDI5bOrU0xrpVYU0rZyjl3LBXInZFMTP/NNSd7IS6Ksdtar0QvnrPRIhVrLQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1259,21 +1243,22 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.3.tgz",
-      "integrity": "sha512-X1NRA4WzK/ihgyzTpeGvI9Wn45y8HmqF4AZ/FazwAv8V203Ex+4lXqcYI70naX9ETqbqKVzFk88W6WJJzCggTQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.4.tgz",
+      "integrity": "sha512-1hTy6UYRYqOZlHKH2/2NzdNQ4NNmW2Lp0sYYvztKy+dEQuLvZL9w88zCzFQqqFer3DMcscYOshImxkJTGdV+rg==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.1.3",
-        "@smithy/types": "^2.10.1",
+        "@smithy/querystring-parser": "^2.1.4",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
-      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.2.0.tgz",
+      "integrity": "sha512-RiQI/Txu0SxCR38Ky5BMEVaFfkNTBjpbxlr2UhhxggSmnsHDQPZJWMtPoXs7TWZaseslIlAWMiHmqRT3AV/P2w==",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.2.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1323,13 +1308,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.4.tgz",
-      "integrity": "sha512-J6XAVY+/g7jf03QMnvqPyU+8jqGrrtXoKWFVOS+n1sz0Lg8HjHJ1ANqaDN+KTTKZRZlvG8nU5ZrJOUL6VdwgcQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.6.tgz",
+      "integrity": "sha512-lM2JMYCilrejfGf8WWnVfrKly3vf+mc5x9TrTpT++qIKP452uWfLqlaUxbz1TkSfhqm8RjrlY22589B9aI8A9w==",
       "dependencies": {
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
+        "@smithy/property-provider": "^2.1.4",
+        "@smithy/smithy-client": "^2.4.4",
+        "@smithy/types": "^2.11.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -1338,16 +1323,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.4.tgz",
-      "integrity": "sha512-dvBhPpjpIdGKyJZZ0STFCcvak79Q6brgyZhsebfiAX/zB5paYuqmkG6hMUW7QqZFQ7kCldtOUzwV75MuXaiuhA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.6.tgz",
+      "integrity": "sha512-UmUbPHbkBJCXRFbq+FPLpVwiFPHj1oPWXJS2f2sy23PtXM94c9X5EceI6JKuKdBty+tzhrAs5JbmPM/HvmDB8Q==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/credential-provider-imds": "^2.2.5",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
+        "@smithy/config-resolver": "^2.1.5",
+        "@smithy/credential-provider-imds": "^2.2.6",
+        "@smithy/node-config-provider": "^2.2.5",
+        "@smithy/property-provider": "^2.1.4",
+        "@smithy/smithy-client": "^2.4.4",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1355,12 +1340,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.4.tgz",
-      "integrity": "sha512-/qAeHmK5l4yQ4/bCIJ9p49wDe9rwWtOzhPHblu386fwPNT3pxmodgcs9jDCV52yK9b4rB8o9Sj31P/7Vzka1cg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.5.tgz",
+      "integrity": "sha512-tgDpaUNsUtRvNiBulKU1VnpoXU1GINMfZZXunRhUXOTBEAufG1Wp79uDXLau2gg1RZ4dpAR6lXCkrmddihCGUg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/types": "^2.10.1",
+        "@smithy/node-config-provider": "^2.2.5",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1379,11 +1364,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
-      "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.4.tgz",
+      "integrity": "sha512-5yYNOgCN0DL0OplME0pthoUR/sCfipnROkbTO7m872o0GHCVNJj5xOFJ143rvHNA54+pIPMLum4z2DhPC2pVGA==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1391,12 +1376,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.3.tgz",
-      "integrity": "sha512-Kbvd+GEMuozbNUU3B89mb99tbufwREcyx2BOX0X2+qHjq6Gvsah8xSDDgxISDwcOHoDqUWO425F0Uc/QIRhYkg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.4.tgz",
+      "integrity": "sha512-JRZwhA3fhkdenSEYIWatC8oLwt4Bdf2LhHbNQApqb7yFoIGMl4twcYI3BcJZ7YIBZrACA9jGveW6tuCd836XzQ==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.1.3",
-        "@smithy/types": "^2.10.1",
+        "@smithy/service-error-classification": "^2.1.4",
+        "@smithy/types": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1404,17 +1389,17 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.3.tgz",
-      "integrity": "sha512-HvpEQbP8raTy9n86ZfXiAkf3ezp1c3qeeO//zGqwZdrfaoOpGKQgF2Sv1IqZp7wjhna7pvczWaGUHjcOPuQwKw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.4.tgz",
+      "integrity": "sha512-CiWaFPXstoR7v/PGHddFckovkhJb28wgQR7LwIt6RsQCJeRIHvUTVWhXw/Pco6Jm6nz/vfzN9FFdj/JN7RTkxQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-base64": "^2.1.1",
+        "@smithy/fetch-http-handler": "^2.4.4",
+        "@smithy/node-http-handler": "^2.4.2",
+        "@smithy/types": "^2.11.0",
+        "@smithy/util-base64": "^2.2.0",
         "@smithy/util-buffer-from": "^2.1.1",
         "@smithy/util-hex-encoding": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
+        "@smithy/util-utf8": "^2.2.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1433,9 +1418,9 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
-      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.2.0.tgz",
+      "integrity": "sha512-hBsKr5BqrDrKS8qy+YcV7/htmMGxriA1PREOf/8AGBhHIZnfilVv1Waf1OyKhSbFW15U/8+gcMUQ9/Kk5qwpHQ==",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
@@ -1469,15 +1454,15 @@
       "dev": true
     },
     "node_modules/@types/chai": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.9.tgz",
-      "integrity": "sha512-69TtiDzu0bcmKQv3yg1Zx409/Kd7r0b5F1PfpYJfSHzLGtB53547V4u+9iqKYsTu/O2ai6KTb0TInNpvuQ3qmg==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.12.tgz",
+      "integrity": "sha512-zNKDHG/1yxm8Il6uCCVsm+dRdEsJlFoDu73X17y09bId6UwoYww+vFBsAcRzl8knM1sab3Dp1VRikFQwDOtDDw==",
       "dev": true
     },
     "node_modules/@types/debug": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
-      "integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dev": true,
       "dependencies": {
         "@types/ms": "*"
@@ -1496,9 +1481,9 @@
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.3.tgz",
-      "integrity": "sha512-RsOPImTriV/OE4A9qKjMtk2MnXiuLLbcO3nCXK+kvq4nr0iMfFgpjaX3MPLb6f7+EL1FGSelYvuJMV6REH+ZPQ==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
     },
     "node_modules/@types/ms": {
@@ -1508,12 +1493,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
-      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "version": "20.11.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/semver": {
@@ -1523,9 +1508,9 @@
       "dev": true
     },
     "node_modules/@types/sinon": {
-      "version": "10.0.20",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
-      "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
       "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
@@ -2047,19 +2032,18 @@
       "dev": true
     },
     "node_modules/c8": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
-      "integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
+      "integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@istanbuljs/schema": "^0.1.3",
         "find-up": "^5.0.0",
-        "foreground-child": "^2.0.0",
+        "foreground-child": "^3.1.1",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.1.6",
-        "rimraf": "^3.0.2",
         "test-exclude": "^6.0.0",
         "v8-to-istanbul": "^9.0.0",
         "yargs": "^17.7.2",
@@ -2069,7 +2053,7 @@
         "c8": "bin/c8.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14.0"
       }
     },
     "node_modules/c8/node_modules/cliui": {
@@ -2137,9 +2121,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -2518,16 +2502,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -2573,9 +2557,9 @@
       }
     },
     "node_modules/eslint-config-iplayer": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-iplayer/-/eslint-config-iplayer-9.1.0.tgz",
-      "integrity": "sha512-Xxs1d01ATGOMeGPKhF3tP86iAHkXRE3ByU4/ZKoi32iZO4ICxNpwH4VHHFl6w2UJupme39Wvg84LAletuIilAA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-iplayer/-/eslint-config-iplayer-9.2.0.tgz",
+      "integrity": "sha512-FM5zj/JtI3i+nCnw0sP2bOqfXS1QP4Nkx2fnMLhdNZzVdQmwXl31eDpEt2WeGABJYIDjh5g3TfYcG6iYP4/HIQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -2610,9 +2594,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
-      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -3002,16 +2986,19 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fs.realpath": {
@@ -3152,9 +3139,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3931,12 +3918,12 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
       "dependencies": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/make-error": {
@@ -3980,9 +3967,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
+      "integrity": "sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==",
       "dev": true,
       "dependencies": {
         "ansi-colors": "4.1.1",
@@ -3992,13 +3979,12 @@
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.2.0",
+        "glob": "8.1.0",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
         "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -4013,10 +3999,6 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
@@ -4026,6 +4008,25 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -4066,18 +4067,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4402,9 +4391,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -4428,9 +4417,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -4768,15 +4757,21 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/sinon": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.0.tgz",
-      "integrity": "sha512-p4lJiYKBoOEVUxxVIC9H1MM2znG1/c8gud++I2BauJA5hsz7hHsst35eurNWXTusBsIq66FzOQbZ/uMdpvbPIQ==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
+      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
@@ -4974,9 +4969,9 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -5150,9 +5145,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5178,9 +5173,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lcov": "c8 mocha && c8 report --reporter=lcov",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --fix",
-    "format": "prettier --loglevel warn --write \"**/*.{js,json,jsx,md,ts,tsx,html}\"",
+    "format": "prettier --log-level warn --write \"**/*.{js,json,jsx,md,ts,tsx,html}\"",
     "format:check": "prettier --check \"**/*.{js,json,jsx,md,ts,tsx,html}\"",
     "build": "npm run clean && tsc",
     "prepublishOnly": "npm run build",
@@ -38,27 +38,27 @@
   ],
   "homepage": "https://github.com/bbc/sqs-producer",
   "devDependencies": {
-    "@types/chai": "^4.3.9",
-    "@types/debug": "^4.1.10",
-    "@types/mocha": "^10.0.3",
-    "@types/node": "^20.8.7",
-    "@types/sinon": "^10.0.20",
-    "chai": "^4.3.10",
-    "eslint": "^8.52.0",
-    "eslint-config-iplayer": "^9.1.0",
-    "eslint-config-prettier": "^9.0.0",
-    "mocha": "^10.2.0",
-    "c8": "^8.0.1",
-    "prettier": "^3.0.3",
-    "sinon": "^17.0.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "@types/chai": "^4.3.12",
+    "@types/debug": "^4.1.12",
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^20.11.25",
+    "@types/sinon": "^17.0.3",
+    "chai": "^4.4.1",
+    "eslint": "^8.57.0",
+    "eslint-config-iplayer": "^9.2.0",
+    "eslint-config-prettier": "^9.1.0",
+    "mocha": "^10.3.0",
+    "c8": "^9.1.0",
+    "prettier": "^3.2.5",
+    "sinon": "^17.0.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.2"
   },
   "dependencies": {
-    "@aws-sdk/client-sqs": "^3.507"
+    "@aws-sdk/client-sqs": "^3.529.1"
   },
   "peerDependencies": {
-    "@aws-sdk/client-sqs": "^3.507"
+    "@aws-sdk/client-sqs": "^3.529.1"
   },
   "mocha": {
     "spec": "test/**/**/*.test.ts",


### PR DESCRIPTION
This PR upgrades dependencies to the latest versions available, outside of chai v5 which causes issues with the tests.

A ticket for Chai v5 has been raised here: https://github.com/bbc/sqs-producer/issues/104