### PR TITLE
chore: add documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+
+      - name: NPM Audit
+        run: npx audit-ci
+
+      - name: Install Node Modules
+        run: npm ci
+
+      - name: Build Docs
+        run: npm run generate-docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: './public'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .nyc_output
 .idea
 .DS_Store
+public

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ lib-cov
 coverage/
 .nyc_output/
 test
+public

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 bake-scripts
 dist
+public

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/5220635a4598c9f1a546/maintainability)](https://codeclimate.com/github/bbc/sqs-producer/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/5220635a4598c9f1a546/test_coverage)](https://codeclimate.com/github/bbc/sqs-producer/test_coverage)
 
-Enqueues messages onto a given SQS queue
+Enqueues messages onto a given SQS queue.
 
 ## Installation
 
@@ -25,6 +25,10 @@ npm install sqs-producer
 ### Node Version
 
 We will only support Node versions that are actively or security supported by the Node team. If you are still using an Node 14, please use a version of this library before the v3.2.1 release, if you are using Node 16, please use a version before the v3.3.0 release.
+
+## Documentation
+
+Visit [https://bbc.github.io/sqs-producer/](https://bbc.github.io/sqs-producer/) for the full API documentation.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Enqueues messages onto a given SQS queue
 
 ## Installation
 
+To install this package, enter the following command into your terminal (or the variant of whatever package manager you are using):
+
 ```
 npm install sqs-producer
 ```
@@ -78,7 +80,7 @@ await producer.send([
 //
 // deduplicationId can be excluded if content-based deduplication is enabled
 //
-// http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queue-recommendations.html
+// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queue-recommendations.html
 await producer.send({
   id: 'testId',
   body: 'Hello world from our FIFO queue!',
@@ -89,7 +91,7 @@ await producer.send({
 
 ### Credentials
 
-By default the consumer will look for AWS credentials in the places [specified by the AWS SDK](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials). The simplest option is to export your credentials as environment variables:
+By default the consumer will look for AWS credentials in the places [specified by the AWS SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials). The simplest option is to export your credentials as environment variables:
 
 ```bash
 export AWS_SECRET_ACCESS_KEY=...
@@ -123,7 +125,7 @@ await producer.send(['msg1', 'msg2']);
 
 ### Test
 
-```
+```bash
 npm test
 ```
 
@@ -131,7 +133,7 @@ npm test
 
 For coverage report, run the command:
 
-```
+```bash
 npm run coverage
 ```
 
@@ -139,10 +141,16 @@ npm run coverage
 
 To check for problems using ESLint
 
-```
+```bash
 npm run lint
 ```
 
 ## Contributing
 
-See [contributing guildlines](./.github/CONTRIBUTING.md)
+We welcome and appreciate contributions for anyone who would like to take the time to fix a bug or implement a new feature.
+
+But before you get started, [please read the contributing guidelines](https://github.com/bbc/sqs-producer/blob/main/.github/CONTRIBUTING.md) and [code of conduct](https://github.com/bbc/sqs-producer/blob/main/.github/CODE_OF_CONDUCT.md).
+
+## License
+
+SQS Producer is distributed under the Apache License, Version 2.0, see [LICENSE](./LICENSE) for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "prettier": "^3.2.5",
         "sinon": "^17.0.1",
         "ts-node": "^10.9.2",
+        "typedoc": "^0.25.12",
         "typescript": "^5.4.2"
       },
       "engines": {
@@ -1801,6 +1802,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -3828,6 +3835,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -3926,11 +3939,29 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4742,6 +4773,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -5144,6 +5187,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
+      "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
@@ -5219,6 +5307,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",
     "watch": "tsc --watch",
-    "clean": "rm -fr dist/*"
+    "clean": "rm -fr dist/*",
+    "generate-docs": "typedoc"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -36,7 +37,7 @@
     "producer",
     "queue"
   ],
-  "homepage": "https://github.com/bbc/sqs-producer",
+  "homepage": "https://bbc.github.io/sqs-producer/",
   "devDependencies": {
     "@types/chai": "^4.3.12",
     "@types/debug": "^4.1.12",
@@ -52,6 +53,7 @@
     "prettier": "^3.2.5",
     "sinon": "^17.0.1",
     "ts-node": "^10.9.2",
+    "typedoc": "^0.25.12",
     "typescript": "^5.4.2"
   },
   "dependencies": {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,6 @@
+/**
+ * Error thrown when a message fails to send.
+ */
 export class FailedMessagesError extends Error {
   /** Ids of messages that failed to send. */
   public failedMessages: string[];

--- a/src/format.ts
+++ b/src/format.ts
@@ -2,6 +2,12 @@ import { SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs';
 import { Message } from './types';
 import { isObject, isString, isMessageAttributeValid } from './validation';
 
+/**
+ * Converts a message object to a SendMessageBatchRequestEntry
+ * @param message - The message to convert
+ * @returns The SendMessageBatchRequestEntry
+ * @throws Will throw an error if the message is invalid
+ */
 function entryFromObject(message: Message): SendMessageBatchRequestEntry {
   if (!message.body) {
     throw new Error(`Object messages must have 'body' prop`);
@@ -69,6 +75,10 @@ function entryFromObject(message: Message): SendMessageBatchRequestEntry {
   return entry;
 }
 
+/**
+ * Converts a message string to a SendMessageBatchRequestEntry
+ * @param message The message to convert
+ */
 function entryFromString(message: string): SendMessageBatchRequestEntry {
   return {
     Id: message,
@@ -76,6 +86,11 @@ function entryFromString(message: string): SendMessageBatchRequestEntry {
   };
 }
 
+/**
+ * Converts a message to a SendMessageBatchRequestEntry using the appropriate method
+ * depending on if the message is a string or an object
+ * @param message The message to convert
+ */
 export function toEntry(
   message: string | Message
 ): SendMessageBatchRequestEntry {

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -10,6 +10,9 @@ import { FailedMessagesError } from './errors';
 
 const requiredOptions = ['queueUrl'];
 
+/**
+ * [Usage](https://bbc.github.io/sqs-producer/index.html#usage)
+ */
 export class Producer {
   static create: (options: ProducerOptions) => Producer;
   queueUrl: string;
@@ -30,6 +33,10 @@ export class Producer {
       });
   }
 
+  /**
+   * Returns the number of messages in the queue.
+   * @returns A promise that resolves to the number of messages in the queue.
+   */
   async queueSize(): Promise<number> {
     const command = new GetQueueAttributesCommand({
       QueueUrl: this.queueUrl,
@@ -45,6 +52,11 @@ export class Producer {
     );
   }
 
+  /**
+   * Send a message to the queue.
+   * @param messages - A single message or an array of messages.
+   * @returns A promise that resolves to the result of the send operation.
+   */
   async send(
     messages: string | Message | (string | Message)[]
   ): Promise<SendMessageBatchResultEntry[]> {
@@ -61,6 +73,11 @@ export class Producer {
     );
   }
 
+  /**
+   * Validate the producer options.
+   * @param options - The producer options to validate.
+   * @throws Error if any required options are missing or invalid.
+   */
   private validate(options: ProducerOptions): void {
     for (const option of requiredOptions) {
       if (!options[option]) {
@@ -72,6 +89,15 @@ export class Producer {
     }
   }
 
+  /**
+   * Send a batch of messages to the queue.
+   * @param failedMessages - An array of failed message IDs.
+   * @param successfulMessages - An array of successful message results.
+   * @param messages - An array of messages to send.
+   * @param startIndex - The index of the first message in the batch.
+   * @returns A promise that resolves to the result of the send operation.
+   * @throws FailedMessagesError
+   */
   private async sendBatch(
     failedMessages?: string[],
     successfulMessages?: SendMessageBatchResultEntry[],
@@ -110,6 +136,10 @@ export class Producer {
   }
 }
 
+/**
+ * Creates a new producer.
+ * @param options - The producer options.
+ */
 Producer.create = (options: ProducerOptions): Producer => {
   return new Producer(options);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,65 @@
 import { MessageAttributeValue, SQSClient } from '@aws-sdk/client-sqs';
 
 export interface ProducerOptions {
+  /**
+   * The URL of the queue to send messages to.
+   */
   queueUrl: string;
+  /**
+   * The number of messages to send in a single batch.
+   */
   batchSize?: number;
+  /**
+   * The SQS client to use. If not provided, a new client will be created.
+   */
   sqs?: SQSClient;
+  /**
+   * The AWS region to use. If not provided, the region will be determined
+   * from the `AWS_REGION` environment variable or will default to `eu-west-1.
+   */
   region?: string;
+  /**
+   * In cases where a QueueUrl is given as input, that
+   * will be preferred as the request endpoint.
+   *
+   * Set this value to false to ignore the QueueUrl and use the
+   * client's resolved endpoint, which may be a custom endpoint.
+   */
   useQueueUrlAsEndpoint?: boolean;
 }
 
 export interface Message {
+  /**
+   * An identifier for the message. This must be unique within
+   * the batch of messages.
+   */
   id: string;
+  /**
+   * The messages contents.
+   */
   body: string;
+  /**
+   * This parameter applies only to FIFO (first-in-first-out) queues.
+   * When set messages that belong to the same message group are processed
+   * in a FIFO manner
+   */
   groupId?: string;
+  /**
+   * This parameter applies only to FIFO (first-in-first-out) queues.
+   * The token used for deduplication of messages within a 5-minute minimum
+   * deduplication interval. If a message with a particular id is sent successfully,
+   * subsequent messages with the same id are accepted
+   * successfully but aren't delivered.
+   */
   deduplicationId?: string;
+  /**
+   * The length of time, in seconds, for which to delay a specific message.
+   * Valid values: 0 to 900. Maximum: 15 minutes.
+   */
   delaySeconds?: number;
+  /**
+   * Each message attribute consists of a Name, Type, and Value. For more
+   * information, see [Amazon SQS message attributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html).
+   */
   messageAttributes?: { [key: string]: MessageAttributeValue };
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,11 +1,23 @@
+/**
+ * Checks if the value is a string
+ * @param value - The value to check
+ */
 export function isString(value: any): boolean {
   return typeof value === 'string' || value instanceof String;
 }
 
+/**
+ * Checks if the value is an object
+ * @param value - The value to check
+ */
 export function isObject(value: any): boolean {
   return value && typeof value === 'object' && value instanceof Object;
 }
 
+/**
+ * Checks if a MessageAttribute is valid
+ * @param messageAttribute - The MessageAttribute to check
+ */
 export function isMessageAttributeValid(messageAttribute: any): boolean {
   if (!messageAttribute.DataType) {
     throw new Error('A MessageAttribute must have a DataType key');

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "sort": ["kind", "instance-first", "required-first", "alphabetical"],
+  "treatWarningsAsErrors": false,
+  "searchInComments": true,
+  "entryPoints": ["./src/index.ts"],
+  "out": "public",
+  "name": "SQS Producer",
+  "hideGenerator": true,
+  "navigationLinks": {
+    "GitHub": "https://github.com/bbc/sqs-producer"
+  }
+}


### PR DESCRIPTION
Some time ago we added documentation to SQS Consumer in this PR: https://github.com/bbc/sqs-consumer/pull/347

Unfortunately, we never got around to doing the same for this package.

This PR resolves that by using typedoc (same package as we use on Consumer) to generate documentation from comments within the code.

Alongside that, it also fixes some issues in the readme where we were still using `http` URLs, adds comments around the code to describe the functionality and creates a workflow to deploy the documentation to GitHub Pages.